### PR TITLE
remove quotes around value of font-family so that value is correctly interpreted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,7 @@ joplin.plugins.register({
                 }
 
                 await panels.setHtml(view, `
-                    <div class="outline-content" style="
-                        font-family: ${fontFamily}
-                    '>
+                    <div class="outline-content" style="font-family: ${fontFamily}">
                         <a class="header" href="javascript:;"">OUTLINE</a>
                         <div class="container" style="
                             font-size: ${fontSize}pt;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,8 +114,8 @@ joplin.plugins.register({
                 }
 
                 await panels.setHtml(view, `
-                    <div class="outline-content" style='
-                        font-family: "${fontFamily}"
+                    <div class="outline-content" style="
+                        font-family: ${fontFamily}
                     '>
                         <a class="header" href="javascript:;"">OUTLINE</a>
                         <div class="container" style="


### PR DESCRIPTION
The default value for font-family is `var(--joplin-font-family)`

I think that with quotes around this default value, it's interpreted as a literal and you get the "wrong" presentation.

With the quotes removed, the var is interpolated you get the "right" presentation (i.e. the font referred to by the variable).

![image](https://user-images.githubusercontent.com/60824/111706390-725c6480-87ff-11eb-86d6-7dd537e302b5.png)

![image](https://user-images.githubusercontent.com/60824/111706587-c5ceb280-87ff-11eb-9462-412f4574cbf8.png)
