### PR TITLE
fix a typo -- double-quote (not single) ==> &quot; entity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ function escapeHtml(unsafe:string) {
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/'/g, '&quot;')
+        .replace(/"/g, '&quot;')
         .replace(/'/g, '&#039;');
 }
 


### PR DESCRIPTION
In e2c352260de5bd2c4187980f69da1b3a5eaabcb5 the escaping of a double-quote was changed to a single quote. This seems to be a typo because the following line actually handles single-quotes correctly.

With this change you'll see that a single-quote in a heading tag displays correctly as a single-quote in the outline.

# Before

![image](https://user-images.githubusercontent.com/60824/112509479-bc889d00-8d4d-11eb-93f4-bfa322a4e10c.png)

# After

![image](https://user-images.githubusercontent.com/60824/112509044-54d25200-8d4d-11eb-88bd-218ca5815a3f.png)
