### PR TITLE
Fix an extra space caused by the custom style

### DIFF
--- a/src/webview.js
+++ b/src/webview.js
@@ -13,7 +13,7 @@ function copyInnerLink(dataset, text) {
   webviewApi.postMessage({
     name: 'contextMenu',
     hash: dataset.slug,
-    content: text,
+    content: text.trim(),
   });
 
   document.getElementById('header').innerHTML = 'Copy successful!';


### PR DESCRIPTION
### Problem

When using custom style to add `::before ` pseudo-element on `.toc-item` element, it causes the `<span>${await getHeaderPrefix(header.level)} </span>` element to be rendered. Causes the `innerText` of the `.toc-item` element to get a space before the string. As a result, the text content of "right click to paste markdown inner link" will have an extra space.

### Example

Add the following style to the `$profileDir/outline.css` file:

```css
.toc-item-1 { counter-reset: item2counter; }
.toc-item-2 { counter-reset: item3counter; }
.toc-item-3 { counter-reset: item4counter; }
.toc-item-4 { counter-reset: item5counter; }
.toc-item-5 { counter-reset: item6counter; }

.toc-item-2:before {
  counter-increment: item2counter;
  content: counter(item2counter) ".";
     opacity: 0.5;
}
.toc-item-3:before {
  counter-increment: item3counter;
  content: counter(item2counter) "."
            counter(item3counter) ".";
     opacity: 0.5;
}
.toc-item-4:before {
  counter-increment: item4counter;
  content: counter(item2counter) "."
            counter(item3counter) "."
            counter(item4counter) ".";
     opacity: 0.5;
}
.toc-item-5:before {
  counter-increment: item5counter;
  content: counter(item2counter) "."
            counter(item3counter) "."
            counter(item4counter) "."
            counter(item5counter) ".";
     opacity: 0.5;
}
.toc-item-6:before {
  counter-increment: item6counter;
  content: counter(item2counter) "."
            counter(item3counter) "."
            counter(item4counter) "."
            counter(item5counter) "."
            counter(item6counter) ".";
     opacity: 0.5;
}
```

The results below:

![space](https://gcore.jsdelivr.net/gh/LightAPIs/PicGoImg@master/img/202301211617288.jpg)

The reault of copying "Header A" is `[test# Header A](:/2fda63fe0401450fa2a4ab093a35da99#header-a)`.

### Solution

Use `trim()` method removes whitespace from both ends of a string.
