### PR TITLE
Fixes #99: Do not render formulas in header codeblocks.

### DIFF
--- a/src/markdownHeaders.test.ts
+++ b/src/markdownHeaders.test.ts
@@ -114,3 +114,104 @@ test('86 spaces before code block', () => {
     slug: 'comment',
   });
 });
+
+test('99 codeblocks in header', () => {
+  const headers = markdownHeaders(
+    readFileSync('./test/99-codeblocks_in_header.md', 'utf-8')
+  );
+  expect(headers.length).toBe(12);
+
+  // Simple cases:
+  expect(headers[0]).toEqual({
+    html: 'text <code>$a</code>',
+    level: 1,
+    lineno: 0,
+    number: "1",
+    slug: 'text-a',
+  });
+  expect(headers[1]).toEqual({
+    html: 'text <code>$a, $b</code>',
+    level: 1,
+    lineno: 2,
+    number: "2",
+    slug: 'text-b',
+  });
+  expect(headers[2]).toEqual({
+    html: 'text <code>$a, $b, $c</code>',
+    level: 1,
+    lineno: 4,
+    number: "3",
+    slug: 'text-b-c',
+  });
+  expect(headers[3]).toEqual({
+    html: 'text <code>$a, $b, $c</code> text',
+    level: 1,
+    lineno: 6,
+    number: "4",
+    slug: 'text-b-c-text',
+  });
+
+  // Multi backtick codeblocks (w/o dollar-sign):
+  expect(headers[4]).toEqual({
+    html: 'text <code>a ` b</code>',
+    level: 1,
+    lineno: 8,
+    number: "5",
+    slug: 'text-a-b',
+  });
+  expect(headers[5]).toEqual({
+    html: 'text <code>a `` b</code>',
+    level: 1,
+    lineno: 10,
+    number: "6",
+    slug: 'text-a-b-2',
+  });
+  expect(headers[6]).toEqual({
+    html: 'text <code>a `` b</code> text',
+    level: 1,
+    lineno: 12,
+    number: "7",
+    slug: 'text-a-b-text',
+  });
+
+  // Multi backtick codeblocks (with dollar-sign):
+  expect(headers[7]).toEqual({
+    html: 'text <code>$a ` $b</code>',
+    level: 1,
+    lineno: 14,
+    number: "8",
+    slug: 'text-b-2',
+  });
+  expect(headers[8]).toEqual({
+    html: 'text <code>$a `` $b</code>',
+    level: 1,
+    lineno: 16,
+    number: "9",
+    slug: 'text-b-3',
+  });
+  expect(headers[9]).toEqual({
+    html: 'text <code>$a `` $b</code> text',
+    level: 1,
+    lineno: 18,
+    number: "10",
+    slug: 'text-b-text',
+  });
+
+  // Two codeblocks:
+  expect(headers[10]).toEqual({
+    html: 'text <code>$a</code> text <code>b ` $c</code>',
+    level: 1,
+    lineno: 20,
+    number: "11",
+    slug: 'text-c',
+  });
+
+  // Escaped backtick:
+  expect(headers[11]).toEqual({
+    html: 'text ` text <code>$a</code>',
+    level: 1,
+    lineno: 22,
+    number: "12",
+    slug: 'text-text-a',
+  });
+});

--- a/test/99-codeblocks_in_header.md
+++ b/test/99-codeblocks_in_header.md
@@ -1,0 +1,23 @@
+# text `$a`
+
+# text `$a, $b`
+
+# text `$a, $b, $c`
+
+# text `$a, $b, $c` text
+
+# text ``a ` b``
+
+# text ```a `` b```
+
+# text ```a `` b``` text
+
+# text ``$a ` $b``
+
+# text ```$a `` $b```
+
+# text ```$a `` $b``` text
+
+# text `$a` text ``b ` $c``
+
+# text \` text `$a`


### PR DESCRIPTION
Issue #99 is being caused by formula-parsing within code blocks. Some languages (s.a., PHP/Hack) use `$` as part of their variable names, so a heading such as "## Documentation of `$length`" would treat the `$` as a formula opening. Having two variables with a `$` in a title would be interpreted as a `$`-enclosed formula.

Example of the issue:

<img width="2160" height="410" alt="Screenshot 2025-10-13 at 8 47 47 AM" src="https://github.com/user-attachments/assets/74f6875d-faab-4985-be30-425d673d64f1" />

The fix in this pull request isolates code blocks and only runs formula-parsing on non-code block parts of the heading. A code block is any matching pair of one or more consecutive back ticks; the matching of multiple consecutive back ticks is needed when back ticks themselves are part of a code block. Due to this matching constraint, a simple regular expression cannot be used here and headlines need to be parsed manually.

My implementation is reasonably efficient (imo):

1. it scans once for the presence of a back tick; $O(length(heading))$
2. if no back tick is present, the original implementation runs
3. if a back tick is present, then proceed to iterate through the heading once;  $O(length(heading))$
4. stitch together non-code blocks and code blocks; $O(length(heading))$

So, the implementation is $3 \times O(length(heading)) = O(length(heading))$ in the end. There is no back tracking. The code is self-contained (no external dependencies).

Examples of the fix in action:

<img width="2103" height="720" alt="Screenshot 2025-10-19 at 9 24 13 PM" src="https://github.com/user-attachments/assets/2851516b-f900-4bb9-afa6-ae2d47f3e0d4" />

This code was *not* generated. I did use ChatGPT to help me track down a bug for a corner case though.

Fixes #99 